### PR TITLE
修复三个u8相加导致溢出、调用get_flag出现MovePrimitiveRuntimeError错误的问题

### DIFF
--- a/src/02_lets_move/lets_move/sources/lets_move.move
+++ b/src/02_lets_move/lets_move/sources/lets_move.move
@@ -40,10 +40,10 @@ module lets_move::lets_move {
 
         let hash: vector<u8> = hash::sha3_256(full_proof);
 
-        let mut prefix_sum = 0;
+        let mut prefix_sum: u32 = 0;
         let mut i: u64 = 0;
         while (i < challenge.difficulity) {
-            prefix_sum = prefix_sum + *vector::borrow(&hash, i);
+            prefix_sum = prefix_sum + (*vector::borrow(&hash, i) as u32);
             i = i + 1;
         };
 


### PR DESCRIPTION
代码里面prefix_sum是u8类型，在三个u8相加是可能会溢出，所以会出现类似这种莫名其妙的错误：Error executing transaction: Failure {
    error: "MovePrimitiveRuntimeError(MoveLocationOpt(Some(MoveLocation { module: ModuleId { address: b77aedc8e4ab254fe4109b7044ae4148f98fab96efb7d534dc8f259f60636cd1, name: Identifier(\"lets_move\") }, function: 1, instruction: 34, function_name: Some(\"get_flag\") }))) in command 0",
}